### PR TITLE
Add lower bound on primitive and Data.Parser to exposed-modules

### DIFF
--- a/stdio.cabal
+++ b/stdio.cabal
@@ -22,6 +22,7 @@ library
                             Data.Vector
                             Data.Array
                             Data.Array.Checked
+                            Data.Parser
                             Data.Text
                             Data.Text.UTF8Codec
 
@@ -33,7 +34,7 @@ library
     -- other-extensions:    
     build-depends:          base >=4.6 && <4.10
                         ,   ghc-prim
-                        ,   primitive
+                        ,   primitive >= 0.6.2
                         ,   deepseq
                         ,   template-haskell 
 


### PR DESCRIPTION
Just two small fixes to the cabal file that I made to be able to build
it successfully.