### PR TITLE
Miscellaneous windows related fixes

### DIFF
--- a/bench/diskIO/AutoFFI.hs
+++ b/bench/diskIO/AutoFFI.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Main where
 
 import System.Posix.Internals (c_read, c_open, c_close, c_write, o_RDWR, o_CREAT, o_NONBLOCK)
@@ -26,7 +27,7 @@ main = do
         let file' = file ++ "-" ++ show i
         withCString file $ \ fp -> do
             withCString file' $ \ fp' -> do
-#if !defined(mingw32_HOST_OS)
+#if defined(mingw32_HOST_OS)
                 fd <- c_open (castPtr fp) (o_RDWR .|. o_NONBLOCK) 0o666
                 fd' <- c_open (castPtr fp') (o_CREAT .|. o_RDWR .|. o_NONBLOCK) 0o666
 #else

--- a/bench/diskIO/AutoFFI.hs
+++ b/bench/diskIO/AutoFFI.hs
@@ -11,6 +11,9 @@ import System.Environment
 import Data.Bits
 import Data.IORef.Unboxed
 import System.IO.Unsafe
+#if defined(mingw32_HOST_OS)
+import Foreign.Ptr (castPtr)
+#endif
 
 unsafeCounter :: Counter
 unsafeCounter = unsafePerformIO $ do newCounter 0
@@ -23,8 +26,13 @@ main = do
         let file' = file ++ "-" ++ show i
         withCString file $ \ fp -> do
             withCString file' $ \ fp' -> do
+#if !defined(mingw32_HOST_OS)
+                fd <- c_open (castPtr fp) (o_RDWR .|. o_NONBLOCK) 0o666
+                fd' <- c_open (castPtr fp') (o_CREAT .|. o_RDWR .|. o_NONBLOCK) 0o666
+#else
                 fd <- c_open fp (o_RDWR .|. o_NONBLOCK) 0o666
                 fd' <- c_open fp' (o_CREAT .|. o_RDWR .|. o_NONBLOCK) 0o666
+#endif
                 loop fd fd'
                 c_close fd
                 c_close fd'

--- a/bench/diskIO/SafeFFI.hs
+++ b/bench/diskIO/SafeFFI.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Main where
 
 import System.Posix.Internals (c_safe_read, c_safe_open, c_close, c_safe_write, o_RDWR, o_CREAT, o_NONBLOCK)
@@ -7,6 +8,9 @@ import Control.Monad
 import Control.Concurrent.Async (forConcurrently_)
 import System.Environment
 import Data.Bits
+#if defined(mingw32_HOST_OS)
+import Foreign.Ptr (castPtr)
+#endif
 
 main :: IO ()
 main = do
@@ -15,8 +19,13 @@ main = do
         let file' = file ++ "-" ++ show i
         withCString file $ \ fp -> do
             withCString file' $ \ fp' -> do
+#if defined(mingw32_HOST_OS)
+                fd <- c_safe_open (castPtr fp) (o_RDWR .|. o_NONBLOCK) 0o666
+                fd' <- c_safe_open (castPtr fp') (o_CREAT .|. o_RDWR .|. o_NONBLOCK) 0o666
+#else
                 fd <- c_safe_open fp (o_RDWR .|. o_NONBLOCK) 0o666
                 fd' <- c_safe_open fp' (o_CREAT .|. o_RDWR .|. o_NONBLOCK) 0o666
+#endif
                 loop fd fd'
                 c_close fd
                 c_close fd'

--- a/bench/timers/timers.cabal
+++ b/bench/timers/timers.cabal
@@ -41,3 +41,5 @@ executable system-timer
   hs-source-dirs:       ./
   ghc-options:         -O2 -threaded -with-rtsopts=-N4
   default-language:    Haskell2010
+  if os(windows)
+    buildable:         False

--- a/cbits/win32.c
+++ b/cbits/win32.c
@@ -8,21 +8,4 @@
 
 #include "HsBase.h"
 
-int get_unique_file_info(int fd, HsWord64 *dev, HsWord64 *ino)
-{
-    HANDLE h = (HANDLE)_get_osfhandle(fd);
-    BY_HANDLE_FILE_INFORMATION info;
-
-    if (GetFileInformationByHandle(h, &info))
-    {
-        *dev = info.dwVolumeSerialNumber;
-        *ino = info.nFileIndexLow
-             | ((HsWord64)info.nFileIndexHigh << 32);
-
-        return 0;
-    }
-
-    return -1;
-}
-
 #endif


### PR DESCRIPTION
This patch includes

+ Cast between `CString` and `CWString`, due to the definition of `CFilePath`.
+ Remove the custom `get_unique_file_info`, since it exists from base-4.5.0
+ Disable executable SystemTimer on windows, currently (base-4.9.1.0) the interface `GHC.Event` still unavailable on windows.